### PR TITLE
update python runtime from 3.8 to 3.12

### DIFF
--- a/onboarding-assistant/README.md
+++ b/onboarding-assistant/README.md
@@ -40,6 +40,8 @@ You will need this value to configure Slack interactivity and subscriptions
 * Under the **Select Menus** heading ensure that the **Options Load URL** field us using the API Gateway Base URL defined above with a `/production/search` suffix
   * Should look something like `https://API_ID_HERE.execute-api.us-east-1.amazonaws.com/production/search`
 
+⚠️ **NOTE:** clicking the form button requires a response within 3 seconds, ensure the interactivity endpoint is responsive -- may require adjusting cold start settings including the warmup function to make sure this works consistently
+
 #### Ensure Event Subscriptions is enabled
 
 * Navigate to [Event Subscriptions](https://api.slack.com/apps/A010YT72ADN/event-subscriptions?)

--- a/onboarding-assistant/README.md
+++ b/onboarding-assistant/README.md
@@ -1,6 +1,6 @@
 # Onboarding assistant
 
-⚠️ **Warning:** commits pushed to the `master` branch get automatically deployed to the production environment through AWS CodeBuild on the `he-sandbox2` account at the `us-east-1` region.
+⚠️ **Warning:** commits pushed to the `master` branch get automatically deployed to the production environment through AWS CodeBuild on the `he-sandbox2` account at the `us-east-1` region. If too many builds are done in a short timeframe, Serverless framework images may get throttled by Docker registry leading to rate exceeded errors.
 
 ## Common maintenance operations
 If you're in charge of updating this application and don't have prior

--- a/onboarding-assistant/code/requirements.txt
+++ b/onboarding-assistant/code/requirements.txt
@@ -1,36 +1,42 @@
-aiobotocore==1.1.2; python_version >= "3.6"
-aiohttp==3.7.4; python_version >= "3.6"
-aioitertools==0.7.0; python_version >= "3.6"
-airtable==0.3.1
-async-timeout==3.0.1; python_full_version >= "3.5.3"
-attrs==19.3.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-boto3==1.14.1
-botocore==1.17.44
-certifi==2019.11.28
-chardet==3.0.4
-click==7.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-docutils==0.15.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
-flask==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-fsspec==0.8.4; python_version > "3.6"
-googlemaps==4.4.0; python_version >= "3.5"
-idna==2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-itsdangerous==1.1.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-jinja2==2.11.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-jmespath==0.9.5
-markupsafe==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-multidict==4.7.5; python_version >= "3.5"
-pyee==7.0.1
-pymemcache==3.0.1
-python-dateutil==2.8.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
-pytz==2019.3
-requests==2.23.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-s3fs==0.5.1; python_version >= "3.6"
-s3transfer==0.3.3
-six==1.14.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
-slackclient==2.5.0; python_full_version >= "3.6.0"
-slackeventsapi==2.1.0
-typing-extensions==3.7.4.3
-urllib3==1.25.8; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
-werkzeug==1.0.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-wrapt==1.12.1
-yarl==1.4.2; python_version >= "3.5"
+aiobotocore==2.22.0
+aiohappyeyeballs==2.6.1
+aiohttp==3.11.18
+aioitertools==0.12.0
+aiosignal==1.3.2
+airtable==0.4.8
+async-timeout==5.0.1
+attrs==25.3.0
+blinker==1.9.0
+boto3==1.37.3
+botocore==1.37.3
+certifi==2025.4.26
+chardet==5.2.0
+charset-normalizer==3.4.2
+click==8.2.1
+docutils==0.21.2
+Flask==3.1.1
+frozenlist==1.6.0
+fsspec==2025.5.0
+googlemaps==4.10.0
+idna==3.10
+itsdangerous==2.2.0
+Jinja2==3.1.6
+jmespath==1.0.1
+MarkupSafe==3.0.2
+multidict==6.4.4
+propcache==0.3.1
+pyee==11.1.1
+pymemcache==4.0.0
+python-dateutil==2.9.0.post0
+pytz==2025.2
+requests==2.32.3
+s3fs==2025.5.0
+s3transfer==0.11.3
+six==1.17.0
+slackclient==2.9.4
+slackeventsapi==3.0.3
+typing_extensions==4.13.2
+urllib3==2.4.0
+Werkzeug==3.1.3
+wrapt==1.17.2
+yarl==1.20.0

--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -34,7 +34,7 @@ provider:
       Resource: "*"
   name: aws
   region: us-east-1
-  runtime: python3.8
+  runtime: python3.11
   stage: ${opt:stage, "production"}
   environment:
     SECRET_ARN: "${env:SECRET_ARN}"
@@ -45,12 +45,12 @@ functions:
   form:
     handler: code/handler.handle_form_submission
     memorySize: 128
-    runtime: python3.8
+    runtime: python3.11
     timeout: 25
   analytics:
     handler: analytics.event_worker
     memorySize: 128
-    runtime: python3.8
+    runtime: python3.11
     timeout: 25
   events:
     events:
@@ -60,7 +60,7 @@ functions:
           path: /events
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.8
+    runtime: python3.11
     timeout: 25
   interactivity:
     events:
@@ -70,7 +70,7 @@ functions:
           path: /interactivity
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.8
+    runtime: python3.11
     timeout: 25
   shortener:
     events:
@@ -80,7 +80,7 @@ functions:
           path: /{any+}
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.8
+    runtime: python3.11
     timeout: 25
   menu:
     events:

--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -120,7 +120,7 @@ custom:
     createRoute53Record: true
   pythonRequirements:
     dockerizePip: true
-    dockerImage: python:3.12
+    dockerImage: python:3.12-bookworm # needed for gcc for deps like yarl
     usePoetry: false
     fileName: code/requirements.txt
     vendor: code/modules

--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -120,6 +120,7 @@ custom:
     createRoute53Record: true
   pythonRequirements:
     dockerizePip: true
+    dockerImage: public.ecr.aws/lambda/python:3.12
     usePoetry: false
     fileName: code/requirements.txt
     vendor: code/modules

--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -34,7 +34,7 @@ provider:
       Resource: "*"
   name: aws
   region: us-east-1
-  runtime: python3.11
+  runtime: python3.12
   stage: ${opt:stage, "production"}
   environment:
     SECRET_ARN: "${env:SECRET_ARN}"
@@ -45,12 +45,12 @@ functions:
   form:
     handler: code/handler.handle_form_submission
     memorySize: 128
-    runtime: python3.11
+    runtime: python3.12
     timeout: 25
   analytics:
     handler: analytics.event_worker
     memorySize: 128
-    runtime: python3.11
+    runtime: python3.12
     timeout: 25
   events:
     events:
@@ -60,7 +60,7 @@ functions:
           path: /events
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.11
+    runtime: python3.12
     timeout: 25
   interactivity:
     events:
@@ -70,7 +70,7 @@ functions:
           path: /interactivity
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.11
+    runtime: python3.12
     timeout: 25
   shortener:
     events:
@@ -80,7 +80,7 @@ functions:
           path: /{any+}
     handler: wsgi_handler.handler
     memorySize: 128
-    runtime: python3.11
+    runtime: python3.12
     timeout: 25
   menu:
     events:

--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -120,7 +120,7 @@ custom:
     createRoute53Record: true
   pythonRequirements:
     dockerizePip: true
-    dockerImage: public.ecr.aws/lambda/python:3.12
+    dockerImage: python:3.12
     usePoetry: false
     fileName: code/requirements.txt
     vendor: code/modules


### PR DESCRIPTION
* The `3.8` runtime is no longer supported for several features in AWS
* The latest version is currently `3.13` but we are stepping forward more incrementally based on what has been verified so far
* TODO: get functions to latest version for Python and NodeJS runtimes