### PR TITLE
keep interactivity function warm

### DIFF
--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -68,6 +68,9 @@ functions:
         http:
           method: any
           path: /interactivity
+    warmup:
+      default:
+        enabled: true
     handler: wsgi_handler.handler
     memorySize: 128
     runtime: python3.12


### PR DESCRIPTION
* Slack requires responsiveness within 3 seconds which we are currently exceeding