### PR TITLE
Revert "enable python lambda layers"

### DIFF
--- a/onboarding-assistant/serverless.yml
+++ b/onboarding-assistant/serverless.yml
@@ -127,7 +127,6 @@ custom:
     usePoetry: false
     fileName: code/requirements.txt
     vendor: code/modules
-    layer: true
   warmup:
     default:
       enabled: false


### PR DESCRIPTION
Reverts helpfulengineering/tool-slack-automation#26

the Serverless Framework is creating the custom Layer but not properly configuring it for the functions