### PR TITLE
[onboarding] add __init__.py to fix handler import

### DIFF
--- a/onboarding-assistant/code/__init__.py
+++ b/onboarding-assistant/code/__init__.py
@@ -1,0 +1,2 @@
+# code/__init__.py
+# Only necessary to get Python to recognize the code directory as a module


### PR DESCRIPTION
*  Python 3.12 tightened the import rules, and AWS Lambda now requires code to be a proper package (i.e., it must contain `__init__.py`) for code.handler to be importable

Closes #28 